### PR TITLE
Disable caching on preview URLs

### DIFF
--- a/Controller/SlugController.php
+++ b/Controller/SlugController.php
@@ -61,7 +61,9 @@ class SlugController extends Controller
         /* @var HasNodeInterface $entity */
         $entity     = null;
         $node       = $nodeTranslation->getNode();
+        $cache      = true;
         if ($preview) {
+            $cache = false;
             $version = $request->get('version');
             if (!empty($version) && is_numeric($version)) {
                 $nodeVersion = $em->getRepository('KunstmaanNodeBundle:NodeVersion')->find($version);
@@ -114,6 +116,14 @@ class SlugController extends Controller
             throw $this->createNotFoundException('No page found for slug ' . $url);
         }
 
-        return $this->render($view, $renderContext->getArrayCopy());
+        $response = $this->render($view, $renderContext->getArrayCopy());
+
+        if ((!$cache) and ($response instanceof Response)) {
+            $response->setPrivate();
+            $response->setMaxAge(0);
+            $response->headers->addCacheControlDirective('must-revalidate', true);
+        }
+
+        return $response;
     }
 }


### PR DESCRIPTION
This doesn't work though when LiipCacheControl is enabled.

Should we defined behavior to override LiipCacheControl? For now it just tells the Symfony HTTP caching system we don't want any caching. But LiipCacheControl overrides the default system when it's defined in the global project.

So it's important to define a /preview/ rule in the app/config/config.yml.

For example:

```
liip_cache_control:
    rules:
        - { path: /admin, controls: { private: true }, vary: [Accept-Encoding] }
        - { path: /preview/, controls: { private: true }, vary: [Accept-Encoding] }
        - { path: ^/, controls: { public: true, max_age: 120, s_maxage: 240 }, vary: [Accept-Encoding] }
```
