### PR TITLE
fix slugifier: iconv doesn't work as aspected when locale is C or POSIX,...

### DIFF
--- a/Helper/Slugifier.php
+++ b/Helper/Slugifier.php
@@ -17,12 +17,16 @@ class Slugifier
      */
     public static function slugify($text, $default = 'n-a')
     {
+
         $text = preg_replace('#[^\\pL\d\/]+#u', '-', $text); // replace non letter or digits by -
         $text = trim($text, '-'); //trim
 
         // transliterate
         if (function_exists('iconv')) {
+            $previouslocale = setlocale(LC_CTYPE, 0);
+            setlocale(LC_CTYPE, 'en_US.UTF8');
             $text = iconv('utf-8', 'us-ascii//TRANSLIT', $text);
+            setlocale(LC_CTYPE, $previouslocale);
         }
 
         $text = strtolower($text); // lowercase


### PR DESCRIPTION
... see http://www.php.net/manual/en/function.iconv.php

with this fix the title "tést" will be replaced by "test" in the slug and not "tst"
