### PR TITLE
Return any response given from Entity

### DIFF
--- a/Controller/SlugController.php
+++ b/Controller/SlugController.php
@@ -107,7 +107,7 @@ class SlugController extends Controller
         /** @noinspection PhpUndefinedMethodInspection */
         $response = $entity->service($this->container, $request, $renderContext);
 
-        if ($response instanceof RedirectResponse) {
+        if ($response instanceof Response) {
             return $response;
         }
 


### PR DESCRIPTION
This change enables a developer to issue any kind of response to the slug controller.
In my case I need to be able to have normal CMS functionality and a Form in the page. To be able to handle the submission I needed to be able to forward the request to a certain controller.
This can be done by returning a forward response to the slug controller, like so:

```
/**
     * @param ContainerInterface $container The Container
     * @param Request            $request   The Request
     * @param RenderContext      $context   The Render context
     *
     * @return void|RedirectResponse
     */
    public function service(ContainerInterface $container, Request $request, RenderContext $context)
    {
        $path['_controller'] = 'AcmeDemoBundle:Default:test';
        $path['context'] = $context;
        $subRequest = $container->get('request')->duplicate(array(), null, $path);

        return $container->get('http_kernel')->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
    }
```
