### PR TITLE
show offline translated pages in link chooser

### DIFF
--- a/Controller/WidgetsController.php
+++ b/Controller/WidgetsController.php
@@ -65,7 +65,7 @@ class WidgetsController extends Controller
             ->from('kuma_nodes', 'n')
             ->leftJoin('n', 'kuma_node_translations', 't', "(t.node_id = n.id AND t.lang = ?)")
             ->where('n.deleted = 0')
-            ->andWhere('t.online = 1')
+            ->andWhere('t.online IN (0, 1)')
             ->addOrderBy('parent_id', 'ASC')
             ->addOrderBy('weight', 'ASC')
             ->addOrderBy('title', 'ASC');

--- a/Resources/views/Widgets/selectLinkRecTreeView.html.twig
+++ b/Resources/views/Widgets/selectLinkRecTreeView.html.twig
@@ -1,4 +1,4 @@
-<li rel="page">
+<li rel="page" class="{% if item.online == 0 %}offline{% endif %}">
     <a onclick="jQuery('#selection').text('Selection: {{ path('_slug', { 'url': item.url }) }}'); ckurl = '{{ path('_slug', { 'url': item.url }) }}'; ckid = '{{ item.id }}';" class="item" href="#">{{ item.title }}</a>
     <ul>
         {% for item in tree.children(item.id) %}


### PR DESCRIPTION
With this change you'll be able to select links during translation from one to another language without publishing pages.
This will show both online/offline pages that are translated in the url chooser. The offline links will be shown in grey to differentiate them from the online links.
