### PR TITLE
Add internal name field

### DIFF
--- a/Form/NodeMenuTabAdminType.php
+++ b/Form/NodeMenuTabAdminType.php
@@ -18,6 +18,7 @@ class NodeMenuTabAdminType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->add('hiddenFromNav', 'checkbox', array('label' => 'Hidden from menu', 'required' => false));
+        $builder->add('internalName', 'text', array('label' => 'Internal name', 'required' => false));
     }
 
     /**


### PR DESCRIPTION
I use the internal name quite a lot for some pages, and not having to enter it into the database or by writing a migration script would help immensely.
