### PR TITLE
fallback for when _nodeTranslation is not set

### DIFF
--- a/Controller/SlugController.php
+++ b/Controller/SlugController.php
@@ -46,6 +46,10 @@ class SlugController extends Controller
 
         /* @var NodeTranslation $nodeTranslation */
         $nodeTranslation = $request->get('_nodeTranslation');
+        if (!$nodeTranslation) {
+            // When the SlugController is used from a different Routing or RouteLoader class, the _nodeTranslation is not set, so we need this fallback
+            $nodeTranslation = $em->getRepository('KunstmaanNodeBundle:NodeTranslation')->getNodeTranslationForUrl($url, $locale);
+        }
 
         // If no node translation -> 404
         if (!$nodeTranslation) {


### PR DESCRIPTION
In some cases you want to use the slugController from your own Routing or RouteLoader class (where you define custom routes). When this is the case, the `_nodeTranslation` is not set, so we need to build in a fallback. For regular pages, there is not performance impact because we still use the `_nodeTranslation` if possible.
