### PR TITLE
fix naming / reflect standard url & path functionality in get_..._by_internal_name functions

### DIFF
--- a/Twig/NodeTwigExtension.php
+++ b/Twig/NodeTwigExtension.php
@@ -135,15 +135,13 @@ class NodeTwigExtension extends Twig_Extension
             $slug = $translation->getSlug();
         }
 
-        $params = array_merge(
+        return array_merge(
             array(
                 'url'     => $slug,
                 '_locale' => $locale
             ),
             $parameters
         );
-
-        return $params;
     }
 
     /**


### PR DESCRIPTION
Modified Twig extension since naming was a bit off.

Removed get_slug_by_internal_name, created get_url_by_internal_name and get_path_by_internal_name, reflecting the default url() & path() behavior for nodes...
