### PR TITLE
changed check condition for structure nodes to use "isStructureNode()"

### DIFF
--- a/EventListener/NodeTranslationListener.php
+++ b/EventListener/NodeTranslationListener.php
@@ -6,11 +6,11 @@ use Doctrine\ORM\EntityManager,
     Doctrine\ORM\Event\OnFlushEventArgs,
     Doctrine\ORM\Event\PostFlushEventArgs;
 
+use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
 use Kunstmaan\NodeBundle\Entity\Node,
     Kunstmaan\NodeBundle\Entity\NodeTranslation;
 
 use Kunstmaan\NodeBundle\Entity\NodeVersion;
-use Kunstmaan\NodeBundle\Entity\StructureNode;
 use Symfony\Bridge\Monolog\Logger;
 use Symfony\Component\HttpFoundation\Session\Session;
 
@@ -74,8 +74,8 @@ class NodeTranslationListener
                     /** @var $publicNodeVersion NodeVersion */
                     $publicNode = $publicNodeVersion->getRef($em);
 
-                    /** Do nothing for StructureNode objects, return */
-                    if ($publicNode instanceof StructureNode) {
+                    /** Do nothing for structure nodes, return */
+                    if ($publicNode instanceof HasNodeInterface && $publicNode->isStructureNode()) {
                         return;
                     }
 


### PR DESCRIPTION
This listener goes into infinite recursion when saving a Page, if that Page is a structure node, but does not extend `StructureNode` class for whatever reason.

I think it's better to check if it's a structure node by using `isStructureNode()` of `HasNodeInterface`, because one might not want to extend `StructureNode` and `AbstractPage` (which StructureNode extends from) just because of this listener. 