### PR TITLE
Upgrade symfony-cmf/routing-bundle from 1.1 to 1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "gedmo/doctrine-extensions": "2.3.*",
-        "symfony-cmf/routing-bundle": "~1.1.1",
+        "symfony-cmf/routing-bundle": "~1.2",
         "kunstmaan/adminlist-bundle": "~3.2",
         "kunstmaan/admin-bundle": "~3.2",
         "kunstmaan/utilities-bundle": "~3.2",


### PR DESCRIPTION
Upgrade CMF routing bundle tot 1.2 does not break BC.
https://github.com/symfony-cmf/RoutingBundle/blob/master/UPGRADE-1.2.md